### PR TITLE
Update ricecooker requirement to >=0.6.11 to bring in Selenium fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 le-utils>=0.1.3
-ricecooker>=0.6.10
+ricecooker>=0.6.11
 youtube-dl>=2017.10.12
 pycountry>=17.5.14
 html2text==2017.10.4


### PR DESCRIPTION
Specifically, https://github.com/learningequality/ricecooker/pull/132